### PR TITLE
Update documentation to mention parallel processing

### DIFF
--- a/docs/docs/rbtc-audio-converter-guide.md
+++ b/docs/docs/rbtc-audio-converter-guide.md
@@ -6,7 +6,7 @@ slug: /
 
 ## What it does
 
-The RBTC Audio Converter turns WAV files into MP3 files and adds the RBTC metadata automatically. You can select up to 15 files at once, choose the lesson number for each file, and convert them in one batch.
+The RBTC Audio Converter turns WAV files into MP3 files and adds the RBTC metadata automatically. You can select up to 15 files at once, choose the lesson number for each file, and convert them in one batch, with up to 2 files being processed in parallel.
 
 ## Download the app
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docs",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@docusaurus/core": "^3.10.1",
         "@docusaurus/faster": "^3.10.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rbtc-audio-converter",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rbtc-audio-converter",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@mediabunny/mp3-encoder": "^1.49.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rbtc-audio-converter",
   "productName": "rbtc-audio-converter",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "description": "The RBTC Audio Converter is a simple Electron application that allows users to convert audio files to different formats. It supports various audio formats and provides an easy-to-use interface for quick conversions.",
   "main": "src/index.js",


### PR DESCRIPTION
This PR updates the Docusaurus documentation to accurately reflect recent changes in the Electron application.

Changes:
* Updated the `rbtc-audio-converter-guide.md` to state that up to 15 files can be converted in one batch, with up to 2 files processed in parallel.

---
*PR created automatically by Jules for task [4699153038689525969](https://jules.google.com/task/4699153038689525969) started by @daribock*