### PR TITLE
Update parallel workers documentation

### DIFF
--- a/docs/docs/rbtc-audio-converter-guide.md
+++ b/docs/docs/rbtc-audio-converter-guide.md
@@ -6,7 +6,7 @@ slug: /
 
 ## What it does
 
-The RBTC Audio Converter turns WAV files into MP3 files and adds the RBTC metadata automatically. You can select up to 15 files at once, choose the lesson number for each file, and convert them in one batch, with up to 2 files being processed in parallel.
+The RBTC Audio Converter turns WAV files into MP3 files and adds the RBTC metadata automatically. You can select up to 15 files at once, choose the lesson number for each file, and convert them in one batch, with the option to process between 1 and 10 files in parallel (defaults to 2).
 
 ## Download the app
 
@@ -44,8 +44,9 @@ On Windows, you may need to choose **More info** and then **Run anyway**.
 2. Select your WAV files.
 3. Set the lesson number for each file.
 4. Enter the shared metadata once: teacher, city, and subject.
-5. Click **Convert files**.
-6. Wait for the progress screen to finish.
+5. Optionally adjust the maximum number of parallel conversions (1-10).
+6. Click **Convert files**.
+7. Wait for the progress screen to finish.
 
 ## Output
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docs",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docs",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@docusaurus/core": "^3.10.1",
         "@docusaurus/faster": "^3.10.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rbtc-audio-converter",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rbtc-audio-converter",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@mediabunny/mp3-encoder": "^1.49.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rbtc-audio-converter",
   "productName": "rbtc-audio-converter",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "description": "The RBTC Audio Converter is a simple Electron application that allows users to convert audio files to different formats. It supports various audio formats and provides an easy-to-use interface for quick conversions.",
   "main": "src/index.js",


### PR DESCRIPTION
This PR updates the Docusaurus documentation to align with recent features added to the Electron app. Specifically, it reflects that users can now optionally adjust the maximum number of parallel conversions from 1 up to 10 files (defaults to 2).

---
*PR created automatically by Jules for task [15899043832685375883](https://jules.google.com/task/15899043832685375883) started by @daribock*