### PR TITLE
chore: bump version to 0.4.4

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rbtc-audio-converter",
   "productName": "rbtc-audio-converter",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "description": "The RBTC Audio Converter is a simple Electron application that allows users to convert audio files to different formats. It supports various audio formats and provides an easy-to-use interface for quick conversions.",
   "main": "src/index.js",


### PR DESCRIPTION
Bumps the version numbers in the root `package.json` and `docs/package.json` to 0.4.4. 
No user-facing changes were made in the recent commits (only unit tests added), so no documentation updates were necessary.

---
*PR created automatically by Jules for task [16656469360068623014](https://jules.google.com/task/16656469360068623014) started by @daribock*