### PR TITLE
docs: Update documentation and bump patch version

### DIFF
--- a/docs/docs/rbtc-audio-converter-guide.md
+++ b/docs/docs/rbtc-audio-converter-guide.md
@@ -43,7 +43,7 @@ On Windows, you may need to choose **More info** and then **Run anyway**.
 1. Open the app.
 2. Select your WAV files.
 3. Set the lesson number for each file.
-4. Enter the shared metadata once: teacher, city, and subject.
+4. Enter the shared metadata abbreviations once: teacher, city, and subject.
 5. Optionally adjust the maximum number of parallel conversions (1-10).
 6. Click **Convert files**.
 7. Wait for the progress screen to finish.
@@ -52,7 +52,7 @@ On Windows, you may need to choose **More info** and then **Run anyway**.
 
 The app saves the converted MP3 files to your Downloads folder.
 
-Each file name uses the lesson number and the shared metadata, so the files stay organized.
+Each file name uses the WAV file's original creation date, the subject abbreviation, lesson number, city abbreviation, and teacher abbreviation (e.g., `240625 CH 01 MN MM.mp3`), so the files stay organized.
 
 ## Notes
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docs",
-  "version": "0.4.2",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docs",
-      "version": "0.4.2",
+      "version": "0.4.5",
       "dependencies": {
         "@docusaurus/core": "^3.10.1",
         "@docusaurus/faster": "^3.10.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rbtc-audio-converter",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rbtc-audio-converter",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "MIT",
       "dependencies": {
         "@mediabunny/mp3-encoder": "^1.50.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rbtc-audio-converter",
   "productName": "rbtc-audio-converter",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "type": "module",
   "description": "The RBTC Audio Converter is a simple Electron application that allows users to convert audio files to different formats. It supports various audio formats and provides an easy-to-use interface for quick conversions.",
   "main": "src/index.js",


### PR DESCRIPTION
This PR updates the Docusaurus documentation inside the `docs` folder to reflect recent changes in the electron app, specifically around the new inputs for abbreviations and the new file naming format using the original creation date. 

It also bumps the versions in the root `package.json` and `docs/package.json` (as well as their lock files) to `0.4.5` to pass the PR version check.

---
*PR created automatically by Jules for task [12753731191432131079](https://jules.google.com/task/12753731191432131079) started by @daribock*