### PR TITLE
Set App Icon to Logo

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docs",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docs",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "dependencies": {
         "@docusaurus/core": "^3.10.1",
         "@docusaurus/faster": "^3.10.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rbtc-audio-converter",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rbtc-audio-converter",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "MIT",
       "dependencies": {
         "@mediabunny/mp3-encoder": "^1.50.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rbtc-audio-converter",
   "productName": "rbtc-audio-converter",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "type": "module",
   "description": "The RBTC Audio Converter is a simple Electron application that allows users to convert audio files to different formats. It supports various audio formats and provides an easy-to-use interface for quick conversions.",
   "main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ const createWindow = () => {
   const mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
+    icon: logoPath,
     webPreferences: {
       preload: path.join(__dirname, "preload.cjs"),
     },


### PR DESCRIPTION
Modified `src/index.js` to configure the main `BrowserWindow` with the `logo.jpg` as the window icon instead of using the default Electron icon. Bumped the version since it is a small feature fix.

---
*PR created automatically by Jules for task [1869553784469598632](https://jules.google.com/task/1869553784469598632) started by @daribock*