### PR TITLE
docs: update guide and bump versions

### DIFF
--- a/docs/docs/rbtc-audio-converter-guide.md
+++ b/docs/docs/rbtc-audio-converter-guide.md
@@ -61,3 +61,4 @@ Each file name uses the WAV file's original creation date, the subject abbreviat
 - Lesson numbers must be positive whole numbers and are automatically prepopulated sequentially starting from 1.
 - Lesson numbers must be unique across all files in a single batch.
 - If two output files would have the same name, the app adds a suffix so nothing gets overwritten.
+- The app features a custom app logo as its window icon.

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docs",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docs",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "dependencies": {
         "@docusaurus/core": "^3.10.1",
         "@docusaurus/faster": "^3.10.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rbtc-audio-converter",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rbtc-audio-converter",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "license": "MIT",
       "dependencies": {
         "@mediabunny/mp3-encoder": "^1.50.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rbtc-audio-converter",
   "productName": "rbtc-audio-converter",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "description": "The RBTC Audio Converter is a simple Electron application that allows users to convert audio files to different formats. It supports various audio formats and provides an easy-to-use interface for quick conversions.",
   "main": "src/index.js",


### PR DESCRIPTION
- Added note in the Docusaurus guide reflecting the custom app logo icon.
- Bumped version to `0.4.7` for both `package.json` configurations.
- Regenerated `package-lock.json` configurations accordingly.

---
*PR created automatically by Jules for task [6190858693557054569](https://jules.google.com/task/6190858693557054569) started by @daribock*