### PR TITLE
Docs: Update docs and bump versions to 0.5.1

### DIFF
--- a/docs/docs/rbtc-audio-converter-guide.md
+++ b/docs/docs/rbtc-audio-converter-guide.md
@@ -43,7 +43,7 @@ On Windows, you may need to choose **More info** and then **Run anyway**.
 1. Open the app.
 2. Select your WAV files.
 3. Set the lesson number for each file.
-4. Enter the shared metadata abbreviations once: teacher, city, and subject.
+4. Enter the shared metadata abbreviations and full names once: teacher, city, and subject.
 5. Optionally adjust the maximum number of parallel conversions (1-10).
 6. Click **Convert files**.
 7. Wait for the progress screen to finish.
@@ -52,7 +52,7 @@ On Windows, you may need to choose **More info** and then **Run anyway**.
 
 The app saves the converted MP3 files to your Downloads folder.
 
-Each file name uses the WAV file's original creation date, the subject abbreviation, lesson number, city abbreviation, and teacher abbreviation (e.g., `240625 CH 01 MN MM.mp3`), so the files stay organized.
+Each file name uses the WAV file's original creation date, the subject abbreviation, lesson number, city abbreviation, and teacher abbreviation (e.g., `240625 CH 01 MN MM.mp3`), so the files stay organized. The full names are added as audio metadata.
 
 ## Notes
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docs",
-  "version": "0.4.6",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docs",
-      "version": "0.4.6",
+      "version": "0.5.1",
       "dependencies": {
         "@docusaurus/core": "^3.10.1",
         "@docusaurus/faster": "^3.10.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rbtc-audio-converter",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rbtc-audio-converter",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@mediabunny/mp3-encoder": "^1.50.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rbtc-audio-converter",
   "productName": "rbtc-audio-converter",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "description": "The RBTC Audio Converter is a simple Electron application that allows users to convert audio files to different formats. It supports various audio formats and provides an easy-to-use interface for quick conversions.",
   "main": "src/index.js",


### PR DESCRIPTION
This PR updates the Docusaurus documentation to reflect recent changes in the Electron application, specifically mentioning the new metadata inputs (full names) and how they are used.

It also bumps the version numbers in both the root `package.json` and the `docs/package.json` to a higher patch version (`0.5.1`) and syncs their respective `package-lock.json` files.

---
*PR created automatically by Jules for task [5244687133331095471](https://jules.google.com/task/5244687133331095471) started by @daribock*