### PR TITLE
Update docs and bump versions to 0.5.2

### DIFF
--- a/docs/docs/rbtc-audio-converter-guide.md
+++ b/docs/docs/rbtc-audio-converter-guide.md
@@ -46,7 +46,7 @@ On Windows, you may need to choose **More info** and then **Run anyway**.
 4. Enter the shared metadata abbreviations and full names once: teacher, city, and subject.
 5. Optionally adjust the maximum number of parallel conversions (1-10).
 6. Click **Convert files**.
-7. Wait for the progress screen to finish.
+7. Wait for the progress screen to finish. Upon successful conversion, a button will appear to open your Downloads folder directly.
 
 ## Output
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docs",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docs",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@docusaurus/core": "^3.10.1",
         "@docusaurus/faster": "^3.10.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rbtc-audio-converter",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rbtc-audio-converter",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "@mediabunny/mp3-encoder": "^1.50.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rbtc-audio-converter",
   "productName": "rbtc-audio-converter",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "description": "The RBTC Audio Converter is a simple Electron application that allows users to convert audio files to different formats. It supports various audio formats and provides an easy-to-use interface for quick conversions.",
   "main": "src/index.js",


### PR DESCRIPTION
This PR updates the Docusaurus documentation to reflect recent changes to the Electron app (specifically, mentioning the new "Open Downloads Folder" button). It also bumps the application version from `0.5.1` to `0.5.2` in both the root and `docs` directory `package.json` and updates the corresponding lock files.

---
*PR created automatically by Jules for task [17056696969708222109](https://jules.google.com/task/17056696969708222109) started by @daribock*