### PR TITLE
chore: bump version to 0.5.4 in package.json and docs/package.json

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docs",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docs",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "dependencies": {
         "@docusaurus/core": "^3.10.2",
         "@docusaurus/faster": "^3.10.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rbtc-audio-converter",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rbtc-audio-converter",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "MIT",
       "dependencies": {
         "@mediabunny/mp3-encoder": "^1.50.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rbtc-audio-converter",
   "productName": "rbtc-audio-converter",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "type": "module",
   "description": "The RBTC Audio Converter is a simple Electron application that allows users to convert audio files to different formats. It supports various audio formats and provides an easy-to-use interface for quick conversions.",
   "main": "src/index.js",


### PR DESCRIPTION
- Bumps version from 0.5.3 to 0.5.4 in both package.json files.
- Updates package-lock.json files accordingly.
- No docs changes were needed as the current features (parallel limit, 15 max files limit) were already up to date in the guide.

---
*PR created automatically by Jules for task [4842705352307773938](https://jules.google.com/task/4842705352307773938) started by @daribock*